### PR TITLE
Fix in bot.reply(): message initialization

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -24,9 +24,11 @@ function botDefinition (botkit, configuration) {
 	}
 
 	bot.reply = (src, resp, cb) => {
-		const message = resp;
+		let message = {};
 		if (typeof(resp) == 'string') {
-			message.text = Object.assign({}, resp);
+			message.text = resp;
+		} else {
+			message = resp;
 		}
 
 		src.response = message;


### PR DESCRIPTION
Hello,
The `bot.reply()` code fails because the `message` variable remains a string and does not become an object. This leads to a rejection from discord.js.
I believe the reason is that it is initialized as a const:
```
const message = resp;
```
which prevents any further changes, especially this one:
```
message.text = Object.assign({}, resp);
```

I rewrote these few lines and was able to test it successfully.
I hope this helps,
Thanks for your hard work,
Yann