### PR TITLE
Fix the Erlpack package issue  - fixes #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "botkit": "^0.6.21",
     "clone-deep": "^4.0.1",
     "discord.js": "^11.4.2",
-    "erlpack": "github:hammerandchisel/erlpack",
+    "erlpack": "^0.1.3",
     "lodash.omit": "^4.5.0",
     "uws": "^99.0.0"
   },


### PR DESCRIPTION
By switching back to the original Erlpack package as suggested in [this issue in the discord/erlpack fork](https://github.com/discord/erlpack/issues/34), the project installs again.

I made a simple bot from scratch, using the README instructions, and it seems to work fine.
