### PR TITLE
Add undef protection to categorize

### DIFF
--- a/middleware/categorize.js
+++ b/middleware/categorize.js
@@ -18,6 +18,11 @@ const categorize = (bot, message) => {
 		message.type = 'direct_message';
 	}
 
+	// Next two checks need message.text to not be undefined
+	if (message.text === undefined) {
+		message.text = ""
+	}
+
 	if (isMention(botId, message.text)) {
 		message.type = 'mention';
 

--- a/test.js
+++ b/test.js
@@ -69,6 +69,10 @@ test('Categorize: Check Accurate Types', t => {
 	insertMessage.text = 'hello! <@123456>';
 	const mentionMessage = middlewares.categorize.exec(botStub, insertMessage);
 	t.is(mentionMessage.type, 'mention');
+
+	insertMessage.text = undefined;
+	const undefMessage = middlewares.categorize.exec(botStub, insertMessage);
+	t.is(mentionMessage.type, 'mention');
 });
 
 test('Format: Correct Attachments, Embeds, and Responses', t => {


### PR DESCRIPTION
In some cases, messages arrive with message.text set to undefined. This
causes the iSMention check in categorize.js to fail and causes
CoreBot.js to throw a "An error occurred in the categorize middleware:
TypeError: Cannot read property 'indexOf' of undefined" error.

Add a check for the message text being undefined so we skip the mention
and direct_mention checks (they can't pass anyway if the message is
undefined).